### PR TITLE
Add .gitattributes to fix line endings for Windows devcontainer users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Auto-detect text files and normalize to LF in the repo
+* text=auto
+
+# Shell scripts must use LF (they run in Linux containers/devcontainers)
+*.sh text eol=lf
+entrypoint.sh text eol=lf
+
+# Python files - LF is standard
+*.py text eol=lf
+
+# Dockerfiles run in Linux
+Dockerfile text eol=lf
+
+# Config files that might be used in containers
+*.yaml text eol=lf
+*.yml text eol=lf
+*.json text eol=lf
+*.toml text eol=lf
+*.bicep text eol=lf
+
+# Windows scripts need CRLF
+*.bat text eol=crlf
+*.cmd text eol=crlf
+*.ps1 text eol=crlf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
I was testing out our repo on Windows in a devcontainer and azd up failed with /bin/sh: 1: ./infra/auth_init.sh: not found, even though the file existed.

Windows Git defaults to converting line endings to CRLF (users can disable this, some don't, like me), which breaks shell scripts in the devcontainer.

Added a .gitattributes file to enforce correct line endings per-repo, so it works for everyone automatically.