### PR TITLE
Add remote build to keycloak

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -18,6 +18,7 @@ services:
     language: docker
     host: containerapp
     docker:
+      remoteBuild: true
       path: ./keycloak/Dockerfile
       context: .
   agent:


### PR DESCRIPTION
We are using it for other services, so we should be consistent and use it for keycloak, or remove it from other two. I like using it since then I don't have to have Docker running/installed, but it does have a drawback of not working with Azure Free Trial.